### PR TITLE
Remove sorting of results

### DIFF
--- a/javascript/script.js
+++ b/javascript/script.js
@@ -21,8 +21,7 @@ submitForm.onsubmit = (e) => {
 	const currentVal = search.value;
 	getSearchedLocation(currentVal)
 		.then((data) => {
-			const sortedResults = data?.results?.sort((a, b) => a.name?.length - b.name?.length);
-			const result = sortedResults?.find((result) => result.name && result.country);
+			const result = data?.results.find((result) => result.name && result.country);
 			if (result) {
 				const latitude = result.latitude;
 				const longitude = result.longitude;


### PR DESCRIPTION
När man söker på "Stockholm" så finns "Glendale" med i resultatet, eftersom det är kortare än "Stockholm" så hamnar det först när man sorterar listan på längd. Tar därför bort sorteringen av listan så att vi inte får det felet :)